### PR TITLE
fix compile error on non-linux platforms

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,7 @@ default['ubuntu']['archive_url']  = 'http://us.archive.ubuntu.com/ubuntu'
 default['ubuntu']['security_url'] = 'http://security.ubuntu.com/ubuntu'
 default['ubuntu']['include_source_packages'] = true
 default['ubuntu']['components'] = 'main restricted universe multiverse'
-default['ubuntu']['codename'] = node['lsb']['codename']
+default['ubuntu']['codename'] = (node['lsb'] || {})['codename']
 
 # If you want to limit the repositories to a specifc arch set this to an array of archs
 default['ubuntu']['architectures'] = nil


### PR DESCRIPTION
bit of a wonk, but cookbooks depending on ubuntu cookbook currently blow up during compile phase if run on a platform that doesn't set `node['lsb']` (e.g. mac_os_x), even if they're not trying to run recipes from the ubuntu cookbook. this aims to fix that.
